### PR TITLE
Fix for pretty-printing of Modules with no internal signals

### DIFF
--- a/netlist-to-vhdl/Language/Netlist/GenVHDL.hs
+++ b/netlist-to-vhdl/Language/Netlist/GenVHDL.hs
@@ -16,7 +16,7 @@ module Language.Netlist.GenVHDL(genVHDL) where
 import Language.Netlist.AST
 
 import Text.PrettyPrint
-import Data.Maybe(catMaybes)
+import Data.Maybe(catMaybes, mapMaybe)
 
 
 -- | Generate a 'Language.Netlist.AST.Module' as a VHDL file . The ['String'] argument
@@ -56,8 +56,7 @@ architecture m = text "architecture" <+> text "str" <+> text "of" <+>  text (mod
                  text "end" <+> text "architecture" <+> text "str" <> semi
 
 decls :: [Decl] -> Doc
-decls [] = empty
-decls ds = (vcat $ punctuate semi $ catMaybes $ map decl ds) <> semi
+decls = vcat . map (<> semi) . mapMaybe decl
 
 decl :: Decl -> Maybe Doc
 decl (NetDecl i r Nothing) = Just $
@@ -82,10 +81,7 @@ decl (MemDecl i (Just asize) dsize def) = Just $
 decl _d = Nothing
 
 insts ::  [Decl] -> Doc
-insts [] = empty
-insts is = case catMaybes $ zipWith inst gensyms is of
-             [] -> empty
-             is' -> (vcat $ punctuate semi is') <> semi
+insts = vcat . map (<> semi) . catMaybes . zipWith inst gensyms
   where gensyms = ["proc" ++ show i | i <- [(0::Integer)..]]
 
 inst :: String -> Decl -> Maybe Doc


### PR DESCRIPTION
(this pull request was recreated because the original one pointed to the wrong commit)

In cases where VHDL syntax requires semicolons _after_ lines, not _between_ them, don't emit a semicolon for empty lists.

This fixes a VHDL syntax error in the pretty-printed output of e.g.

``` haskell
Module "Empty" [] [] [] [InstDecl "work.foo" "foo" [] [] []]
```

which without this patch is pretty-printed as

``` vhdl
library IEEE;
use IEEE.STD_LOGIC_1164.ALL;
use IEEE.NUMERIC_STD.ALL;
entity Empty is
  port();
end entity Empty;
architecture str of Empty is
  ;
begin
  foo : entity work.foo
  port map ();
end architecture str;
```

The stray `;` at the beginning of the `architecture` block is a syntax error in VHDL.
